### PR TITLE
Add sample order invariance to estimator_checks

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -269,8 +269,8 @@ def _yield_all_checks(estimator):
             yield check
     yield check_parameters_default_constructible
     yield check_fit2d_predict1d
-    yield check_methods_subset_invariance
     yield check_methods_sample_order_invariance
+    yield check_methods_subset_invariance
     yield check_fit2d_1sample
     yield check_fit2d_1feature
     yield check_fit1d
@@ -1146,7 +1146,7 @@ def check_methods_sample_order_invariance(name, estimator_orig):
     set_random_state(estimator, 1)
     estimator.fit(X, y)
 
-    idx = np.random.randint(X.shape[0], size=X.shape[0] // 2)
+    idx = np.random.permutation(X.shape[0])
 
     for method in ["predict", "transform", "decision_function",
                    "score_samples", "predict_proba"]:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1150,7 +1150,7 @@ def check_methods_sample_order_invariance(name, estimator_orig):
 
     for method in ["predict", "transform", "decision_function",
                    "score_samples", "predict_proba"]:
-        msg = ("{method} of {name} is not invariant when applied to a subset"
+        msg = ("{method} of {name} is not invariant when applied to a dataset"
                "with different sample order.").format(method=method, name=name)
 
         if hasattr(estimator, method):

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -259,20 +259,15 @@ class NotInvariantSampleOrder(BaseEstimator):
             accept_sparse=("csr", "csc"),
             multi_output=True,
             y_numeric=True)
-
-        self.first = X[0]
+        # store the original X to check for sample order later
+        self._X = X
         return self
 
     def predict(self, X):
         X = check_array(X)
-        # check if the sample order is different from the original
-        # or not. If the sample order is different, then just return
-        # an array of zeros.
-        # TODO: For now, im just checking if the first instance in the sample
-        # is the same, but I will write a function to check this
-        if (X[0] != self.first).all():
+        # if the sample order is different, return zeros
+        if (X != self._X).any():
             return np.zeros(X.shape[0])
-
         return X[:,0]
 
 class LargeSparseNotSupportedClassifier(BaseEstimator):
@@ -439,7 +434,7 @@ def test_check_estimator():
     # check for sample order invariance
     name = NotInvariantSampleOrder.__name__
     method = 'predict'
-    msg = ("{method} of {name} is not invariant when applied to a subset"
+    msg = ("{method} of {name} is not invariant when applied to a dataset"
         "with different sample order.").format(method=method, name=name)
     assert_raises_regex(AssertionError, msg,
                         check_estimator, NotInvariantSampleOrder())

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -265,10 +265,13 @@ class NotInvariantSampleOrder(BaseEstimator):
 
     def predict(self, X):
         X = check_array(X)
-        # if the sample order is different, return zeros
-        if (X != self._X).any():
+        # if the input contains the same elements but different sample order,
+        # then just return zeros.
+        if (np.array_equiv(np.sort(X, axis=0), np.sort(self._X, axis=0)) and
+           (X != self._X).any()):
             return np.zeros(X.shape[0])
-        return X[:,0]
+        return X[:, 0]
+
 
 class LargeSparseNotSupportedClassifier(BaseEstimator):
     def fit(self, X, y):
@@ -435,7 +438,7 @@ def test_check_estimator():
     name = NotInvariantSampleOrder.__name__
     method = 'predict'
     msg = ("{method} of {name} is not invariant when applied to a dataset"
-        "with different sample order.").format(method=method, name=name)
+           "with different sample order.").format(method=method, name=name)
     assert_raises_regex(AssertionError, msg,
                         check_estimator, NotInvariantSampleOrder())
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #8695

#### What does this implement/fix? Explain your changes.
Added `check_methods_sample_order_variance` function, which checks for method invariance under sample order (i.e. results should not change when sample before or after applying the method).

#### Any other comments?
The original issue mentions using `assert_array_equal` to check for invariance. While this method works for `predict`, `decision_function`, `score_samples`, and `predict_proba`, it fails for `transform`. Therefore, I have opted for `assert_allclose_dense_sparse` with `atol=1e-9` instead of `assert_array_equal`, which passes the tests for all methods.